### PR TITLE
fix(emqx): wrap Kafka bridge payload as {topic, payload} envelope

### DIFF
--- a/config/emqx/emqx.conf
+++ b/config/emqx/emqx.conf
@@ -74,7 +74,7 @@ actions {
         topic = "telemetry.readings"
         message {
           key = "${.topic}"
-          value = "${.payload}"
+          value = "{\"topic\": \"${.topic}\", \"payload\": ${.payload}}"
           timestamp = "${.timestamp}"
         }
         partition_strategy = "random"
@@ -91,7 +91,7 @@ actions {
         topic = "telemetry.status"
         message {
           key = "${.topic}"
-          value = "${.payload}"
+          value = "{\"topic\": \"${.topic}\", \"payload\": ${.payload}}"
           timestamp = "${.timestamp}"
         }
         partition_strategy = "random"


### PR DESCRIPTION
## Summary
Мост EMQX→Kafka заворачивал в Kafka только сырой MQTT payload, а контракты `EmqxTelemetryMessage` / `EmqxStatusMessage` ожидают конверт `{topic, payload}` — из-за этого collector/devices падали на каждой телеметрии с `ValidationError`, а `extract_ids()` не имел доступа к `topic`.

## Changes
- `config/emqx/emqx.conf`: в обоих actions (`telemetry_readings`, `telemetry_status`) шаблон значения теперь `{"topic": "${.topic}", "payload": ${.payload}}` вместо голого `${.payload}`.

## Verification
- [x] `docker compose restart emqx` — брокер поднимается healthy, конфиг валидный.
- [x] Опубликовал тестовую телеметрию и статус через MQTT (device auth, реальный токен) — `kafka-console-consumer` на `telemetry.readings` и `telemetry.status` показывает сообщения в формате `{"topic": "placebrain/.../telemetry", "payload": {...}}`.
- [x] `docker compose logs collector --since=2m | grep -i validation` — пусто.
- [x] `docker compose logs devices --since=2m | grep -i validation` — пусто.

Closes #1