### PR TITLE
feat(kafka): make consumers wait for kafka-init completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ After a minute or two `docker compose ps` should show all 11 containers healthy.
 
 The `/api/internal/*` prefix is blocked externally and reachable only from inside the Docker network — EMQX calls those webhooks directly at `gateway:8000`.
 
+## Kafka topics
+
+The broker runs with `auto.create.topics.enable=false` (see `config/kafka/server.properties`) so every topic must be declared up front. The `kafka-init` service is a one-shot container that runs `kafka-topics.sh --create --if-not-exists` for each topic once the broker is healthy, then exits.
+
+Consumers (`places`, `devices`, `collector`) wait for `kafka-init` to exit successfully via `depends_on: { kafka-init: { condition: service_completed_successfully } }`. This avoids a cold-start race where a consumer subscribes to a topic that does not yet exist, which would otherwise surface as noisy "unknown topic" warnings.
+
+To add a new topic, add another `kafka-topics.sh --create --if-not-exists ...` line to the `kafka-init` service in `docker-compose.yaml`. Existing topics are idempotent — re-running the stack is safe.
+
 ## Makefile targets
 
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,6 +61,8 @@ services:
         condition: service_healthy
       kafka:
         condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('localhost', 50052)); s.close()"]
       interval: 5s
@@ -86,6 +88,10 @@ services:
       start_period: 30s
     restart: unless-stopped
 
+  # One-shot job that creates all declared Kafka topics on startup.
+  # The broker runs with auto.create.topics.enable=false, so consumers must wait
+  # for this container to exit successfully before subscribing — otherwise they
+  # spam "unknown topic" warnings and can race the broker on cold start.
   kafka-init:
     container_name: placebrain-kafka-init
     image: apache/kafka:4.0.0
@@ -137,6 +143,8 @@ services:
         condition: service_healthy
       kafka:
         condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('localhost', 50053)); s.close()"]
       interval: 5s
@@ -158,6 +166,8 @@ services:
         condition: service_healthy
       kafka:
         condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
       emqx:
         condition: service_healthy
     healthcheck:


### PR DESCRIPTION
## Summary
Consumers (`places`, `devices`, `collector`) were only waiting for Kafka to be healthy, not for `kafka-init` to finish creating the declared topics. With `auto.create.topics.enable=false` this produced noisy "unknown topic" warnings and occasional cold-start races.

## Changes
- `docker-compose.yaml`: added `kafka-init: condition: service_completed_successfully` to `depends_on` of `places`, `devices`, and `collector`
- `docker-compose.yaml`: added a comment above `kafka-init` explaining its one-shot bootstrap role
- `README.md`: added a "Kafka topics" section documenting the bootstrap flow and how to add new topics

## Verification
- [x] `docker compose config --quiet` — parses clean
- [x] `make down && make dev` cold boot: all 11 services reach healthy, `kafka-init` exits with code 0 before `places`/`devices`/`collector` start
- [x] No "unknown topic" / `UnknownTopic` warnings in `devices`, `collector`, `places` logs after cold start
- [x] Only benign consumer-group rebalancing warnings remain (standard aiokafka noise during first join)

Closes #3