### PR TITLE
refactor(emqx): extract place_id/device_id in rule SQL, key by device_id

### DIFF
--- a/config/emqx/emqx.conf
+++ b/config/emqx/emqx.conf
@@ -73,11 +73,11 @@ actions {
       parameters {
         topic = "telemetry.readings"
         message {
-          key = "${.topic}"
-          value = "{\"topic\": \"${.topic}\", \"payload\": ${.payload}}"
+          key = "${.device_id}"
+          value = "{\"place_id\": \"${.place_id}\", \"device_id\": \"${.device_id}\", \"payload\": ${.payload}}"
           timestamp = "${.timestamp}"
         }
-        partition_strategy = "random"
+        partition_strategy = "key_dispatch"
         required_acks = "all_isr"
       }
       resource_opts {
@@ -109,7 +109,7 @@ rule_engine {
   rules {
     telemetry_to_kafka {
       enable = true
-      sql = "SELECT topic, payload, timestamp FROM \"placebrain/+/devices/+/telemetry\""
+      sql = "SELECT nth(2, tokens(topic, '/')) as place_id, nth(4, tokens(topic, '/')) as device_id, payload, timestamp FROM \"placebrain/+/devices/+/telemetry\""
       actions = ["kafka_producer:telemetry_readings"]
     }
     status_to_kafka {


### PR DESCRIPTION
## Summary
EMQX Kafka bridge теперь парсит topic внутри rule SQL и шлёт структурированное событие `TelemetryReading` с первоклассными `place_id`/`device_id`, вместо сырого `{topic, payload}` конверта. Партиционирование — по `device_id` (ordering per-device).

## Changes
- `config/emqx/emqx.conf`: rule `telemetry_to_kafka` — SQL извлекает `place_id = nth(2, tokens(topic,'/'))` и `device_id = nth(4, ...)`
- `config/emqx/emqx.conf`: action `telemetry_readings` — `key = ${.device_id}`, `value` содержит `place_id`/`device_id`/`payload`, `partition_strategy = key_dispatch`
- Action `telemetry_status` не трогаем — out of scope (см. contracts#11 non-goals)

## Verification
- [x] `make dev` — все сервисы healthy
- [x] EMQX rule `telemetry_to_kafka` загружен с новым SQL (`emqx ctl rules show`)
- [x] Full end-to-end через simulator: зарегистрированное устройство публикует MQTT → EMQX rule извлекает IDs → Kafka → collector десериализует `TelemetryReading` → TimescaleDB (136 записей за ~3 минуты, 0 ошибок десериализации)
- [x] Чтение через `/api/places/.../telemetry/latest` возвращает свежие значения
- [x] Action `telemetry_status` для `EmqxStatusMessage` сохранён без изменений

Closes #9

## Must deploy together with
- PlaceBrain/collector#12