### PR TITLE
fix(traefik): silence update check, set ACME email via env, drop empty dynamic mount

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@
 # create per-service databases (auth_db, places_db, devices_db, telemetry_db).
 POSTGRES_USER=backend
 POSTGRES_PASSWORD=change-me-to-a-strong-password
+
+# Email used by Traefik for Let's Encrypt ACME account registration.
+# Required in production; issuance fails without it.
+TRAEFIK_ACME_EMAIL=ops@example.com

--- a/config/traefik/traefik.dev.yaml
+++ b/config/traefik/traefik.dev.yaml
@@ -1,3 +1,7 @@
+global:
+  checkNewVersion: false
+  sendAnonymousUsage: false
+
 entryPoints:
   web:
     address: ":80"
@@ -9,9 +13,6 @@ providers:
     endpoint: "unix:///var/run/docker.sock"
     exposedByDefault: false
     network: placebrain-net
-  file:
-    directory: /etc/traefik/dynamic
-    watch: true
 
 api:
   dashboard: true

--- a/config/traefik/traefik.yaml
+++ b/config/traefik/traefik.yaml
@@ -1,3 +1,7 @@
+global:
+  checkNewVersion: false
+  sendAnonymousUsage: false
+
 entryPoints:
   web:
     address: ":80"
@@ -16,9 +20,6 @@ providers:
     endpoint: "unix:///var/run/docker.sock"
     exposedByDefault: false
     network: placebrain-net
-  file:
-    directory: /etc/traefik/dynamic
-    watch: true
 
 certificatesResolvers:
   letsencrypt:

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -5,7 +5,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./config/traefik/traefik.dev.yaml:/etc/traefik/traefik.yaml:ro
-      - ./config/traefik/dynamic:/etc/traefik/dynamic:ro
 
   postgres:
     ports:

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -4,6 +4,8 @@ services:
       - "80:80"
       - "443:443"
       - "1883:1883"
+    environment:
+      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL: ${TRAEFIK_ACME_EMAIL}
 
   gateway:
     labels:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./config/traefik/traefik.yaml:/etc/traefik/traefik.yaml:ro
-      - ./config/traefik/dynamic:/etc/traefik/dynamic:ro
       - traefik-certs:/etc/traefik/acme
     restart: unless-stopped
 


### PR DESCRIPTION
## Summary
Three small Traefik cleanups so the broker boots clean and prod ACME issuance actually works.

## Changes
- `traefik.yaml` / `traefik.dev.yaml`: set `global.checkNewVersion: false` and `global.sendAnonymousUsage: false` to stop periodic log noise.
- `docker-compose.prod.yaml`: pass `TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL` from `TRAEFIK_ACME_EMAIL` env var so Let's Encrypt registration has a real contact. Added `TRAEFIK_ACME_EMAIL` placeholder to `.env.example`.
- Dropped the empty `/etc/traefik/dynamic` mount (and the `providers.file` block that watched it) from both configs and from base/dev compose; `config/traefik/dynamic/` directory removed.

## Verification
- [x] `docker compose -f docker-compose.yaml -f docker-compose.dev.yaml config -q` — clean.
- [x] `docker compose -f docker-compose.yaml -f docker-compose.prod.yaml config` with `TRAEFIK_ACME_EMAIL` set — email env var renders into the traefik service.
- [x] Booted traefik alone (`docker compose up -d traefik` with dev overlay), logs contain no errors/warnings about missing dynamic dir or anonymous-usage, dashboard API responds (`curl http://localhost:8080/api/overview`).
- [ ] Full `make dev` with all services healthy — skipped; traefik config is the only runtime surface touched and it boots clean.
- [ ] Actual ACME issuance against prod Let's Encrypt — skipped; requires real DNS + production run.

Closes #6