### PR TITLE
chore(traefik): bump to v3.5

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   traefik:
     container_name: placebrain-traefik
-    image: traefik:v3.4
+    image: traefik:v3.5
     networks:
       - placebrain-net
     ports:


### PR DESCRIPTION
## Summary
Upgrades Traefik from v3.4 to v3.5 (latest minor). No config changes required — all keys in use (`global`, `entryPoints`, `providers.docker`, `certificatesResolvers.letsencrypt.acme`, `api`, `log`) and Docker router/tcp labels are stable across 3.4 → 3.5.

## Changes
- Bump `docker-compose.yaml` image tag `traefik:v3.4` → `traefik:v3.5` (pulled 3.5.6)

## Verification
- [x] `make dev` — all services reach `healthy`, Traefik running v3.5.6
- [x] Traefik dashboard/API reachable on `:8080/api/version`
- [x] HTTP routers working: `/docs` → gateway (200), `/` → frontend (200), `/openapi.json` served by gateway
- [x] MQTT TCP entrypoint on `:1883` accepts connections
- [x] `docker compose logs traefik` — no errors or warnings
- [ ] ACME / HTTPS (websecure) not exercised — prod-only flow, dev stack uses HTTP-only `traefik.dev.yaml`

Closes #7