### PR TITLE
feat(dev): hot-reload for all Python backend services

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -13,6 +13,12 @@ services:
   auth:
     build:
       context: ../backend/auth
+    command:
+      - sh
+      - -c
+      - alembic upgrade head &&
+        exec watchfiles --filter python --target-type command 'python -m src.main' src
+    restart: unless-stopped
     volumes:
       - ../backend/auth/src:/app/src
       - ../backend/auth/migrations:/app/migrations
@@ -21,6 +27,12 @@ services:
   places:
     build:
       context: ../backend/places
+    command:
+      - sh
+      - -c
+      - alembic upgrade head &&
+        exec watchfiles --filter python --target-type command 'python -m src.main' src
+    restart: unless-stopped
     volumes:
       - ../backend/places/src:/app/src
       - ../backend/places/migrations:/app/migrations
@@ -42,6 +54,12 @@ services:
   devices:
     build:
       context: ../backend/devices
+    command:
+      - sh
+      - -c
+      - alembic upgrade head &&
+        exec watchfiles --filter python --target-type command 'python -m src.main' src
+    restart: unless-stopped
     volumes:
       - ../backend/devices/src:/app/src
       - ../backend/devices/migrations:/app/migrations
@@ -50,12 +68,18 @@ services:
   collector:
     build:
       context: ../backend/collector
+    command:
+      - sh
+      - -c
+      - exec watchfiles --filter python --target-type command 'python -m src.main' src
+    restart: unless-stopped
     volumes:
       - ../backend/collector/src:/app/src
 
   gateway:
     build:
       context: ../backend/gateway
+    restart: unless-stopped
     volumes:
       - ../backend/gateway/src:/app/src
       - ../var/gateway:/app/var/app


### PR DESCRIPTION
## Summary
Extends hot-reload from `gateway` (already `--reload` via hypercorn) to `auth`, `places`, `devices`, `collector`. In dev, each service now starts under `watchfiles` so edits in `src/` restart the process within ~1s, matching the `gateway` experience.

## Changes
- `docker-compose.dev.yaml`: override `command:` for `auth`, `places`, `devices`, `collector` to wrap their entrypoint with `watchfiles --filter python --target-type command '<orig cmd>' src`. For services with Alembic, migrations still run first.
- `docker-compose.dev.yaml`: `restart: unless-stopped` added for all five backend services so dev containers recover from transient crashes.

## Requires (already merged)
- PlaceBrain/auth#3
- PlaceBrain/places#5
- PlaceBrain/devices#8
- PlaceBrain/collector#14

## Verification
- [x] `docker compose -f docker-compose.yaml -f docker-compose.dev.yaml config` — valid
- [x] `make dev` cold start — all 11 services reach `healthy`
- [x] Edited `backend/<svc>/src/main.py` in `auth`, `places`, `devices` — watchfiles fires `KeyboardInterrupt`, process restarts in ~1s, health returns to `healthy`
- [x] Edited `backend/collector/src/main.py` — watchfiles fires, reload works once
- [ ] `touch` alone (mtime-only) did not trigger reload under Docker Desktop on macOS. Real edits (even a blank-line append) work. Dev-loop quirk of the macOS → container FS event path.

## Known follow-up (out of scope)
On a **second** reload, `collector` fails to reconnect to MQTT (`aiomqtt.MqttConnectError: [code:135] Not authorized`) and enters a watchfiles respawn loop — container stays Up but health goes `unhealthy`. This is a pre-existing collector reconnection bug, now exposed because hot-reload reconnects MQTT frequently. The other four services reload cleanly. Tracking separately is recommended.

Closes #4